### PR TITLE
Take closing parenthesis out of the link

### DIFF
--- a/ndcsydney2016/index.html
+++ b/ndcsydney2016/index.html
@@ -382,7 +382,7 @@
 
 <ul>
 <li>Syntax Visualizer in Visual Studio (<a href="https://github.com/dotnet/roslyn/wiki/Syntax-Visualizer)">https://github.com/dotnet/roslyn/wiki/Syntax-Visualizer)</a></li>
-<li>Roslyn Quoter web app (<a href="http://roslynquoter.azurewebsites.net)">http://roslynquoter.azurewebsites.net)</a></li>
+<li>Roslyn Quoter web app (<a href="http://roslynquoter.azurewebsites.net">http://roslynquoter.azurewebsites.net</a>)</li>
 </ul>
 
 </section>


### PR DESCRIPTION
taking to the Roslyn Quoter